### PR TITLE
Added (dummy) health route

### DIFF
--- a/internal/http/http.go
+++ b/internal/http/http.go
@@ -26,11 +26,17 @@ func New(autoupdate *autoupdate.Autoupdate, auther Auther) *Handler {
 		auther:     auther,
 	}
 	h.mux.Handle("/system/autoupdate", http.HandlerFunc(h.handleAutoupdate))
+	h.mux.Handle("/system/health", http.HandlerFunc(h.handleHealth))
 	return h
 }
 
 func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	h.mux.ServeHTTP(w, r)
+}
+
+func (h *Handler) handleHealth(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	fmt.Fprintln(w, `{"healthy": true}`)
 }
 
 func (h *Handler) handleAutoupdate(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
Hi,

The client needs a way to check, if this service is available, after it lost a connection. Since I do not know, if this service has a "not ready" state (maybe no connection to redis..?) this is a dummy response for now.