### PR TITLE
Add restricter

### DIFF
--- a/cmd/autoupdate/main.go
+++ b/cmd/autoupdate/main.go
@@ -14,6 +14,8 @@ import (
 	"github.com/OpenSlides/openslides3-autoupdate-service/internal/datastore"
 	ahttp "github.com/OpenSlides/openslides3-autoupdate-service/internal/http"
 	"github.com/OpenSlides/openslides3-autoupdate-service/internal/redis"
+	"github.com/OpenSlides/openslides3-autoupdate-service/internal/restricter"
+	"github.com/OpenSlides/openslides3-autoupdate-service/internal/restricter/user"
 )
 
 func main() {
@@ -27,7 +29,13 @@ func main() {
 		log.Fatalf("Can not initialize data: %v", err)
 	}
 
-	service, err := autoupdate.New(ds)
+	restricter := restricter.New(ds, map[string]restricter.Element{
+		"users/user":          user.NewUser(ds),
+		"users/group":         restricter.ElementFunc(user.Group),
+		"users/personal_note": restricter.ElementFunc(user.PersonalNote),
+	})
+
+	service, err := autoupdate.New(ds, restricter)
 	if err != nil {
 		log.Fatalf("Can not create autoupdate service: %v", err)
 	}

--- a/internal/autoupdate/autoupdate_test.go
+++ b/internal/autoupdate/autoupdate_test.go
@@ -16,8 +16,9 @@ func TestAutoupdateReceiveNewData(t *testing.T) {
 		"user:2": []byte("hello world2"),
 	}
 	datastore.Change([]string{"user:1"})
+	restricter := new(test.RestricterMock)
 
-	a, err := autoupdate.New(datastore)
+	a, err := autoupdate.New(datastore, restricter)
 	if err != nil {
 		t.Fatalf("autoupdate startup failed: %v", err)
 	}
@@ -53,7 +54,9 @@ func TestAutoupdateReceiveFirstData(t *testing.T) {
 		"user:2": []byte("hello world2"),
 	}
 
-	a, err := autoupdate.New(datastore)
+	restricter := new(test.RestricterMock)
+
+	a, err := autoupdate.New(datastore, restricter)
 	if err != nil {
 		t.Fatalf("autoupdate startup failed: %v", err)
 	}

--- a/internal/autoupdate/interface.go
+++ b/internal/autoupdate/interface.go
@@ -11,3 +11,8 @@ type Datastore interface {
 	GetMany([]string) map[string]json.RawMessage
 	GetAll() map[string]json.RawMessage
 }
+
+// Restricter restricts data for one user.
+type Restricter interface {
+	Restrict(uid int, data map[string]json.RawMessage)
+}

--- a/internal/datastore/cache.go
+++ b/internal/datastore/cache.go
@@ -30,7 +30,7 @@ func (c *cache) update(changed map[string]json.RawMessage) {
 // with a nil value.
 //
 // Creates a copy of all data.
-func (c *cache) forKeys(keys []string) map[string]json.RawMessage {
+func (c *cache) forKeys(keys ...string) map[string]json.RawMessage {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 
@@ -40,6 +40,16 @@ func (c *cache) forKeys(keys []string) map[string]json.RawMessage {
 		data[key] = append(v[:0:0], v...)
 	}
 	return data
+}
+
+// element returns the element for the key.
+//
+// If a key does not exist in the cache, nil is returned
+func (c *cache) element(key string) json.RawMessage {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	return c.data[key]
 }
 
 // all returns all data from the cache.

--- a/internal/http/http_test.go
+++ b/internal/http/http_test.go
@@ -21,7 +21,9 @@ func TestAutoupdateFirstData(t *testing.T) {
 		"user:2": []byte("hello world2"),
 	}
 
-	a, err := autoupdate.New(datastore)
+	restricter := new(test.RestricterMock)
+
+	a, err := autoupdate.New(datastore, restricter)
 	if err != nil {
 		t.Fatalf("autoupdate startup failed: %v", err)
 	}
@@ -56,7 +58,9 @@ func TestAutoupdateWithChangeID(t *testing.T) {
 		"user:2": []byte("hello world2"),
 	}
 
-	a, err := autoupdate.New(datastore)
+	restricter := new(test.RestricterMock)
+
+	a, err := autoupdate.New(datastore, restricter)
 	if err != nil {
 		t.Fatalf("autoupdate startup failed: %v", err)
 	}
@@ -101,7 +105,9 @@ func TestAuth(t *testing.T) {
 	auther := new(test.AutherMock)
 	datastore := test.NewDatastoreMock(1)
 
-	a, err := autoupdate.New(datastore)
+	restricter := new(test.RestricterMock)
+
+	a, err := autoupdate.New(datastore, restricter)
 	if err != nil {
 		t.Fatalf("autoupdate startup failed: %v", err)
 	}

--- a/internal/restricter/interface.go
+++ b/internal/restricter/interface.go
@@ -1,0 +1,14 @@
+package restricter
+
+import "encoding/json"
+
+// Datastore gives the restricter the full.
+type Datastore interface {
+	GetMany([]string) map[string]json.RawMessage
+	GetAll() map[string]json.RawMessage
+}
+
+// Element knows how to restrict one element.
+type Element interface {
+	Restrict(int, json.RawMessage) (json.RawMessage, error)
+}

--- a/internal/restricter/restricter.go
+++ b/internal/restricter/restricter.go
@@ -1,0 +1,56 @@
+package restricter
+
+import (
+	"encoding/json"
+	"log"
+	"strings"
+)
+
+// Restricter can restrict some data for an user.
+type Restricter struct {
+	datastore Datastore
+	elements  map[string]Element
+}
+
+// New initializes a Restricter
+func New(datastore Datastore, elements map[string]Element) *Restricter {
+	return &Restricter{
+		datastore: datastore,
+		elements:  elements,
+	}
+}
+
+// Restrict changes the data for the given user.
+func (r *Restricter) Restrict(uid int, data map[string]json.RawMessage) {
+	for k, v := range data {
+		parts := strings.Split(k, ":")
+
+		e, ok := r.elements[parts[0]]
+		if !ok {
+			delete(data, k)
+			continue
+		}
+
+		restricted, err := e.Restrict(uid, v)
+		if err != nil {
+			log.Printf("Can not restrict key %s for user %d: %v", k, uid, err)
+			delete(data, k)
+			continue
+		}
+
+		if restricted == nil {
+			delete(data, k)
+			continue
+		}
+		data[k] = restricted
+	}
+}
+
+// ElementFunc converts a simple element restricter func to a element
+// restricter.
+type ElementFunc func(int, json.RawMessage) (json.RawMessage, error)
+
+// Restrict calls the ElementFunc.
+func (f ElementFunc) Restrict(u int, data json.RawMessage) (json.RawMessage, error) {
+	return f(u, data)
+}

--- a/internal/restricter/user/interface.go
+++ b/internal/restricter/user/interface.go
@@ -1,0 +1,6 @@
+package user
+
+// HasPermer tells if a user has a specivic perm.
+type HasPermer interface {
+	HasPerm(uid int, perm string) bool
+}

--- a/internal/restricter/user/user.go
+++ b/internal/restricter/user/user.go
@@ -1,0 +1,107 @@
+package user
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+)
+
+// User handels restrictions of users/user elements.
+type User struct {
+	HasPermer
+}
+
+// NewUser creates a new User.
+func NewUser(hasPermer HasPermer) *User {
+	return &User{
+		HasPermer: hasPermer,
+	}
+}
+
+// Restrict returns the restricted version of the element.
+func (u *User) Restrict(uid int, element json.RawMessage) (json.RawMessage, error) {
+	littleDataFields := []string{
+		"id",
+		"username",
+		"title",
+		"first_name",
+		"last_name",
+		"structure_level",
+		"number",
+		"about_me",
+		"groups_id",
+		"is_present",
+		"is_committee",
+		"vote_weight",
+	}
+
+	manyDataFields := append(littleDataFields, "gender", "email", "last_email_send", "comment", "is_active", "auth_type")
+	allDataFields := append(manyDataFields, "default_password")
+	ownDataFields := append(littleDataFields, "email", "gender")
+
+	if u.HasPerm(uid, "users.can_see_name") {
+		if u.HasPerm(uid, "users.can_see_extra_data") {
+			if u.HasPerm(uid, "users.can_manage") {
+				return filter(element, allDataFields, 0, nil)
+			}
+			return filter(element, manyDataFields, 0, nil)
+		}
+		return filter(element, littleDataFields, uid, ownDataFields)
+	}
+	// TODO: build list of needed users
+	return nil, nil
+}
+
+// Group handles users/group elements.
+func Group(uid int, element json.RawMessage) (json.RawMessage, error) {
+	return element, nil
+}
+
+// PersonalNote is the restricter for users/personal_note
+func PersonalNote(uid int, data json.RawMessage) (json.RawMessage, error) {
+	if uid == 0 {
+		return nil, nil
+	}
+
+	var element struct {
+		UserID int `json:"user_id"`
+	}
+	if err := json.Unmarshal(data, &element); err != nil {
+		return nil, fmt.Errorf("decoding personal element: %w", err)
+	}
+
+	if element.UserID != uid {
+		return nil, nil
+	}
+
+	return data, nil
+}
+
+func filter(value json.RawMessage, fields []string, uid int, ownfields []string) (json.RawMessage, error) {
+	var allData map[string]json.RawMessage
+	if err := json.Unmarshal(value, &allData); err != nil {
+		return nil, fmt.Errorf("unmarshall data: %w", err)
+	}
+
+	filteredData := make(map[string]json.RawMessage, len(fields))
+
+	id, err := strconv.Atoi(string(allData["id"]))
+	if err != nil {
+		return nil, fmt.Errorf("invalid id: %s", allData["id"])
+	}
+
+	useFields := fields
+	if ownfields != nil && uid == id {
+		useFields = ownfields
+	}
+
+	for _, k := range useFields {
+		filteredData[k] = allData[k]
+	}
+
+	filtered, err := json.Marshal(filteredData)
+	if err != nil {
+		return nil, fmt.Errorf("remarshal data: %w", err)
+	}
+	return filtered, nil
+}

--- a/internal/test/restricter.go
+++ b/internal/test/restricter.go
@@ -1,0 +1,15 @@
+package test
+
+import (
+	"encoding/json"
+)
+
+// RestricterMock implements the autoupdate.Restrict interface.
+type RestricterMock struct {
+	Called bool
+}
+
+// Restrict does nothing.
+func (r *RestricterMock) Restrict(uid int, data map[string]json.RawMessage) {
+	r.Called = true
+}


### PR DESCRIPTION
Currently, there is only a restricter for user, group and
personal_note. More to come.

@FinnStutzenstein: Only elements that can be restricted are returned to the client. This means, that you can currently only receive user, groups and personal_notes. If this is a big problem, I can tell you how to disable the restricter. Or I can try to write restricters for other collections as soon as possible.