### PR TITLE
Send keep-alive messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,4 +75,4 @@ The service can be configured with the following environment variables:
 * `WORKER_ADDR`: Host and port of the OpenSlides worker (Default: `http://localhost:8000`).
 * `KEEP_ALIVE_DURATION`: Time in seconds how often a keep alive packet is sent
   to the client. The value `0` means not to send any keep alive packages.
-  (Default: `0`).
+  (Default: `30`).

--- a/README.md
+++ b/README.md
@@ -73,3 +73,6 @@ The service can be configured with the following environment variables:
 * `LISTEN_HTTP_ADDR`: Host and port on which the services listen on (Default: `:8002`).
 * `REDIS_ADDR`: Host and port of the redis service (Default: `localhost:6379`).
 * `WORKER_ADDR`: Host and port of the OpenSlides worker (Default: `http://localhost:8000`).
+* `KEEP_ALIVE_DURATION`: Time in seconds how often a keep alive packet is sent
+  to the client. The value `0` means not to send any keep alive packages.
+  (Default: `0`).

--- a/cmd/autoupdate/main.go
+++ b/cmd/autoupdate/main.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"strconv"
 	"syscall"
 
 	"github.com/OpenSlides/openslides3-autoupdate-service/internal/auth"
@@ -28,61 +29,22 @@ import (
 func main() {
 	listenAddr := getEnv("LISTEN_HTTP_ADDR", ":8002")
 	workerAddr := getEnv("WORKER_ADDR", "http://localhost:8000")
+	keepAliveRaw := getEnv("KEEP_ALIVE_DURATION", "0")
+	keepAlive, err := strconv.Atoi(keepAliveRaw)
+	if err != nil {
+		log.Fatalf("Invalid value for KEEP_ALIVE_DURATION, got %s, expected an int: %v", keepAliveRaw, err)
+	}
 
 	redisConn := redis.New(getEnv("REDIS_ADDR", "localhost:6379"))
 
-	requiredUserCallable := map[string]func(json.RawMessage) ([]int, string, error){
-		"agenda/list-of-speakers":       agenda.RequiredSpeakers,
-		"assignments/assignment":        assignment.RequiredAssignments,
-		"assignments/assignment-poll":   assignment.RequiredPoll,
-		"assignments/assignment-option": assignment.RequiredPollOption,
-		"motions/motion":                motion.RequiredMotions,
-		"motions/motion-option":         motion.RequiredPollOption,
-	}
-
+	requiredUserCallable := openslidesRequiredUsers()
 	ds, err := datastore.New(workerAddr, redisConn, requiredUserCallable)
 	if err != nil {
 		log.Fatalf("Can not initialize data: %v", err)
 	}
 
-	basePerm := restricter.BasePermission(ds)
-
-	restricter := restricter.New(ds, map[string]restricter.Element{
-		"agenda/item":             agenda.Restrict(ds),
-		"agenda/list-of-speakers": basePerm(agenda.CanSeeListOfSpeakers),
-
-		"assignments/assignment":        basePerm(assignment.CanSee),
-		"assignments/assignment-poll":   poll.RestrictPoll(ds, assignment.CanSee, assignment.CanManage, []string{"amount_global_no", "amount_global_abstain"}),
-		"assignments/assignment-option": poll.RestrictOption(ds, assignment.CanSee, assignment.CanManage),
-		"assignments/assignment-vote":   poll.RestrictVote(ds, assignment.CanSee, assignment.CanManage),
-
-		"core/projector":          basePerm(core.CanSeeProjector),
-		"core/projection-default": basePerm(core.CanSeeProjector),
-		"core/projector-message":  basePerm(core.CanSeeProjector),
-		"core/countdown":          basePerm(core.CanSeeProjector),
-		"core/tag":                restricter.ForAll,
-		"core/config":             restricter.ForAll,
-
-		"mediafiles/mediafile": mediafile.Restrict(ds),
-
-		"motions/category":                     basePerm(motion.CanSee),
-		"motions/statute-paragraph":            basePerm(motion.CanSee),
-		"motions/motion":                       motion.Restrict(ds),
-		"motions/motion-block":                 motion.BlockRestrict(ds),
-		"motions/motion-comment-section":       motion.CommentSectionRestrict(ds),
-		"motions/workflow":                     basePerm(motion.CanSee),
-		"motions/motion-change-recommendation": motion.ChangeRecommendationRestrict(ds),
-		"motions/motion-poll":                  poll.RestrictPoll(ds, motion.CanSee, motion.CanManage, nil),
-		"motions/motion-option":                poll.RestrictOption(ds, motion.CanSee, motion.CanManage),
-		"motions/motion-vote":                  poll.RestrictVote(ds, motion.CanSee, motion.CanManage),
-		"motions/state":                        basePerm(motion.CanSee),
-
-		"topics/topic": basePerm("agenda.can_see"),
-
-		"users/user":          user.Restrict(ds),
-		"users/group":         restricter.ForAll,
-		"users/personal-note": restricter.ElementFunc(user.PersonalNoteRestrict),
-	})
+	osRestricters := openslidesRestricters(ds)
+	restricter := restricter.New(ds, osRestricters)
 
 	service, err := autoupdate.New(ds, restricter)
 	if err != nil {
@@ -90,7 +52,7 @@ func main() {
 	}
 
 	auth := auth.New(workerAddr)
-	handler := ahttp.New(service, auth)
+	handler := ahttp.New(service, auth, keepAlive)
 
 	srv := &http.Server{Addr: listenAddr, Handler: handler}
 	defer func() {
@@ -135,4 +97,55 @@ func getEnv(env, devaultValue string) string {
 		return devaultValue
 	}
 	return value
+}
+
+func openslidesRequiredUsers() map[string]func(json.RawMessage) ([]int, string, error) {
+	return map[string]func(json.RawMessage) ([]int, string, error){
+		"agenda/list-of-speakers":       agenda.RequiredSpeakers,
+		"assignments/assignment":        assignment.RequiredAssignments,
+		"assignments/assignment-poll":   assignment.RequiredPoll,
+		"assignments/assignment-option": assignment.RequiredPollOption,
+		"motions/motion":                motion.RequiredMotions,
+		"motions/motion-option":         motion.RequiredPollOption,
+	}
+}
+
+func openslidesRestricters(ds *datastore.Datastore) map[string]restricter.Element {
+	basePerm := restricter.BasePermission(ds)
+	return map[string]restricter.Element{
+		"agenda/item":             agenda.Restrict(ds),
+		"agenda/list-of-speakers": basePerm(agenda.CanSeeListOfSpeakers),
+
+		"assignments/assignment":        basePerm(assignment.CanSee),
+		"assignments/assignment-poll":   poll.RestrictPoll(ds, assignment.CanSee, assignment.CanManage, []string{"amount_global_no", "amount_global_abstain"}),
+		"assignments/assignment-option": poll.RestrictOption(ds, assignment.CanSee, assignment.CanManage),
+		"assignments/assignment-vote":   poll.RestrictVote(ds, assignment.CanSee, assignment.CanManage),
+
+		"core/projector":          basePerm(core.CanSeeProjector),
+		"core/projection-default": basePerm(core.CanSeeProjector),
+		"core/projector-message":  basePerm(core.CanSeeProjector),
+		"core/countdown":          basePerm(core.CanSeeProjector),
+		"core/tag":                restricter.ForAll,
+		"core/config":             restricter.ForAll,
+
+		"mediafiles/mediafile": mediafile.Restrict(ds),
+
+		"motions/category":                     basePerm(motion.CanSee),
+		"motions/statute-paragraph":            basePerm(motion.CanSee),
+		"motions/motion":                       motion.Restrict(ds),
+		"motions/motion-block":                 motion.BlockRestrict(ds),
+		"motions/motion-comment-section":       motion.CommentSectionRestrict(ds),
+		"motions/workflow":                     basePerm(motion.CanSee),
+		"motions/motion-change-recommendation": motion.ChangeRecommendationRestrict(ds),
+		"motions/motion-poll":                  poll.RestrictPoll(ds, motion.CanSee, motion.CanManage, nil),
+		"motions/motion-option":                poll.RestrictOption(ds, motion.CanSee, motion.CanManage),
+		"motions/motion-vote":                  poll.RestrictVote(ds, motion.CanSee, motion.CanManage),
+		"motions/state":                        basePerm(motion.CanSee),
+
+		"topics/topic": basePerm("agenda.can_see"),
+
+		"users/user":          user.Restrict(ds),
+		"users/group":         restricter.ForAll,
+		"users/personal-note": restricter.ElementFunc(user.PersonalNoteRestrict),
+	}
 }

--- a/internal/http/http_test.go
+++ b/internal/http/http_test.go
@@ -28,7 +28,7 @@ func TestAutoupdateFirstData(t *testing.T) {
 	}
 	defer a.Close()
 
-	srv := httptest.NewServer(ahttp.New(a, auther))
+	srv := httptest.NewServer(ahttp.New(a, auther, 0))
 	defer srv.Close()
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -60,7 +60,7 @@ func TestAuth(t *testing.T) {
 	}
 	defer a.Close()
 
-	srv := httptest.NewServer(ahttp.New(a, auther))
+	srv := httptest.NewServer(ahttp.New(a, auther, 0))
 	defer srv.Close()
 
 	ctx, cancel := context.WithCancel(context.Background())


### PR DESCRIPTION
@FinnStutzenstein this is not compatible with the current client. Can you fix the current client to support {} messages. Even for the first data.