### PR TITLE
Prevent buffering in browsers

### DIFF
--- a/internal/notify/http.go
+++ b/internal/notify/http.go
@@ -55,6 +55,10 @@ func (n *Notify) handleNotify(w http.ResponseWriter, r *http.Request) error {
 		return authRequiredError{}
 	}
 
+	w.Header().Set("Content-Type", "application/octet-stream")
+	w.WriteHeader(http.StatusOK)
+	w.(http.Flusher).Flush()
+
 	cid := n.cIDGen.generate(userID)
 	tid := n.topic.LastID()
 


### PR DESCRIPTION
Without the content type header `application/octet-stream`, messages are not directly passed to tje javascript application. Copied from the autoupdate code. Maybe this can be unified for all http streaming endpoints, since the projector endpoint needs this, too.