### PR TITLE
Compress the notify json message

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,8 @@ If a message is received, it has the format:
 {
   "sender_user_id": int -> User id of the sender.
   "sender_channel_id": string -> Channel id of the sender.
-  "message": json -> message send by the sender.
+  "name": string -> Name of the message.
+  "message": json -> Message send by the sender.
 }
 ```
 
@@ -104,14 +105,13 @@ The body has to be a valid json object with at least the fields `channel_id` and
 ```
 {
   "channel_id": string -> channel_id of the sender.
+  "Name": string -> Name of the message.
   "message": json -> valid json containing the message.
   "to_all": bool -> If true, message is send to every connection.
   "to_users": list[int] -> List of user ids that should receive the message.
   "to_channels": list[string] -> List of channel ids that should receive the message.
 }
 ```
-
-Make sure the message does not contain any newline!
 
 
 ## Run Test

--- a/internal/http/http.go
+++ b/internal/http/http.go
@@ -49,6 +49,8 @@ func (h *Handler) handleHealth(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *Handler) handleAutoupdate(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/octet-stream")
+
 	uid, err := h.auther.Auth(r)
 	if err != nil {
 		sendErr(w, fmt.Errorf("authenticate: %w", err))

--- a/internal/notify/http.go
+++ b/internal/notify/http.go
@@ -44,7 +44,7 @@ func (n *Notify) handleSend(w http.ResponseWriter, r *http.Request) error {
 		return invalidRequestError{fmt.Errorf("notify does not have required field `name`")}
 	}
 
-	var buf *bytes.Buffer
+	buf := new(bytes.Buffer)
 	if err := json.Compact(buf, m); err != nil {
 		return invalidRequestError{fmt.Errorf("json is invalid: %w", err)}
 	}


### PR DESCRIPTION
This is required to remove newlines.

This also fixes #33 

@FinnStutzenstein I changed the key of the first object from `channelID` to `channel_id`. I think this is consistent to the other keys. Could you change the client?