### PR TITLE
Fix missing change id

### DIFF
--- a/internal/autoupdate/autoupdate.go
+++ b/internal/autoupdate/autoupdate.go
@@ -56,19 +56,18 @@ func New(datastore Datastore, restricter Restricter, closed <-chan struct{}) (*A
 				continue
 			}
 
+			// When the received data is to new, all the missing data is
+			// received at once. If more then one change id was skipped, the
+			// missing ids have to be created in the topic with dummy items.
 			tid := a.topic.LastID()
-
-			// When the received data is to new, all the missing data is received at
-			// once. If more then one change id was skipped, the missing ids have to be
-			// created in the topic with dummy items.
 			for tid < uint64(changeID)-1 {
 				tid = a.topic.Publish()
 			}
 
-			a.topic.Publish(keys...)
+			tid = a.topic.Publish(keys...)
 
-			// if the topic id is bigger then the change id, then something is broken.
-			// There is no way to recover safely from this.
+			// if the topic id is different then the change id, then something
+			// is broken. There is no way to recover safely from this.
 			if tid != uint64(changeID) {
 				log.Panicf("topic id differs from change id. Topic: %d, changeid %d", tid, changeID)
 			}

--- a/internal/autoupdate/autoupdate.go
+++ b/internal/autoupdate/autoupdate.go
@@ -56,14 +56,16 @@ func New(datastore Datastore, restricter Restricter, closed <-chan struct{}) (*A
 				continue
 			}
 
-			tid := a.topic.Publish(keys...)
+			tid := a.topic.LastID()
 
 			// When the received data is to new, all the missing data is received at
 			// once. If more then one change id was skipped, the missing ids have to be
 			// created in the topic with dummy items.
-			for tid < uint64(changeID) {
+			for tid < uint64(changeID)-1 {
 				tid = a.topic.Publish()
 			}
+
+			a.topic.Publish(keys...)
 
 			// if the topic id is bigger then the change id, then something is broken.
 			// There is no way to recover safely from this.

--- a/internal/autoupdate/http.go
+++ b/internal/autoupdate/http.go
@@ -39,12 +39,13 @@ func (a *Autoupdate) HandleAutoupdate(w http.ResponseWriter, r *http.Request) er
 			return noStatusCodeError{err}
 		}
 
-		if len(data) != 0 {
-			if err := sendData(w, all, data, changeID, newChangeID); err != nil {
-				return noStatusCodeError{err}
-			}
+		if len(data) == 0 {
+			continue
 		}
 
+		if err := sendData(w, all, data, changeID, newChangeID); err != nil {
+			return noStatusCodeError{err}
+		}
 		changeID = newChangeID
 	}
 }

--- a/internal/autoupdate/http_test.go
+++ b/internal/autoupdate/http_test.go
@@ -21,8 +21,8 @@ func TestAutoupdateFirstData(t *testing.T) {
 	auther := new(test.AutherMock)
 	datastore := test.NewDatastoreMock(1, closed)
 	datastore.FullData = map[string]json.RawMessage{
-		"user:1": []byte("hello world1"),
-		"user:2": []byte("hello world2"),
+		"user:1": []byte(`"hello world1"`),
+		"user:2": []byte(`"hello world2"`),
 	}
 
 	restricter := new(test.RestricterMock)


### PR DESCRIPTION
The autoupdate.topic is a bit hacky in the openslides3-autoupdateservice. The tid is used as change_id. If some change_id are missing, then first the missing entries have to be added to the topic. Only then can the new dataset be inserted and gets the correct change_id.

when sending the message to the client, empty data is not sent to the client. But before this change, the last_change_id was updated (and not sent to the client). So it seemed, that data where missing. Now the last_change_id variable is only updated, when data is sent to the client.