### PR TITLE
redis.update can never return empty data.

### DIFF
--- a/internal/apps/assignment/projector.go
+++ b/internal/apps/assignment/projector.go
@@ -113,7 +113,7 @@ func PollSlide() projector.CallableFunc {
 		os := ds.GetModels("assignments/assignment-option", optionIDs)
 
 		optionData := make([]map[string]interface{}, len(os))
-		weight := make([]int, len(os))
+		weight := make([][2]int, len(os))
 		for i, o := range os {
 			var option struct {
 				UserID  int    `json:"user_id"`
@@ -156,11 +156,14 @@ func PollSlide() projector.CallableFunc {
 				data["abstain"] = abstain
 			}
 			optionData[i] = data
-			weight[i] = option.Weight
+			weight[i] = [2]int{option.Weight * 100, option.UserID}
 		}
 
 		sort.Slice(optionData, func(i, j int) bool {
-			return weight[i] < weight[j]
+			if weight[i][0] != weight[j][0] {
+				return weight[i][0] < weight[j][0]
+			}
+			return weight[i][1] > weight[j][1]
 		})
 
 		b, err := json.Marshal(optionData)

--- a/internal/datastore/datastore.go
+++ b/internal/datastore/datastore.go
@@ -78,15 +78,12 @@ func (d *Datastore) CurrentID() int {
 //
 // If the datastore is closed then it return nil, 0, nil.
 func (d *Datastore) KeysChanged() ([]string, int, error) {
-	var rawData []byte
-	var err error
-	for rawData == nil {
-		// Update() blocks until there is new data. But when there is no new
-		// data for an hour, then it returns with nil.
-		rawData, err = d.redisConn.Update(d.closed)
-		if err != nil {
-			return nil, 0, fmt.Errorf("get autoupdate data: %w", err)
-		}
+	rawData, err := d.redisConn.Update(d.closed)
+	if err != nil {
+		return nil, 0, fmt.Errorf("get autoupdate data: %w", err)
+	}
+	if len(rawData) == 0 {
+		return nil, 0, fmt.Errorf("redis returnd empty data. This should never happen. Please cry for help")
 	}
 
 	var sData struct {

--- a/internal/datastore/datastore_test.go
+++ b/internal/datastore/datastore_test.go
@@ -189,7 +189,7 @@ func TestKeysChangedNilDoesNotUnblock(t *testing.T) {
 
 	unblocked := make(chan struct{})
 	go func() {
-		_, _, _ = ds.KeysChanged()
+		_, _, err = ds.KeysChanged()
 		close(unblocked)
 	}()
 
@@ -206,9 +206,14 @@ func TestKeysChangedNilDoesNotUnblock(t *testing.T) {
 	timer.Reset(time.Millisecond)
 	select {
 	case <-unblocked:
-		t.Errorf("KeysChanged was done after sending nil")
 	case <-timer.C:
+		t.Errorf("KeysChanged was not done after sending nil")
 	}
+
+	if err == nil {
+		t.Errorf("Expected error that nil is not expected.")
+	}
+
 }
 
 func TestKeysChangedLowIDDoesNotUnblock(t *testing.T) {

--- a/internal/redis/redis.go
+++ b/internal/redis/redis.go
@@ -213,11 +213,6 @@ func (r *Redis) Update(closing <-chan struct{}) ([]byte, error) {
 	}
 
 	if err != nil {
-		if err == errNil {
-			// No new data
-			return nil, nil
-		}
-
 		return nil, fmt.Errorf("read autoupdate from redis: %w", err)
 	}
 


### PR DESCRIPTION
See also #77

@emanuelschuetze With this PR I removed the for-loop that was necessary since #77. If for reasons that I can not see redis returned empty data, this could have run into an endless loop.

If this situation should happen again (redis returnes empty data) we get a clear error message now. 