### PR TITLE
Fix a panic in projector.go

### DIFF
--- a/internal/apps/agenda/projector.go
+++ b/internal/apps/agenda/projector.go
@@ -258,7 +258,13 @@ func listOfSpeakerSlideData(ds projector.Datastore, los listOfSpeakers) (json.Ra
 	}
 
 	if showNextSpeakers != -1 {
-		speakersWaiting = speakersWaiting[0:showNextSpeakers]
+		showNextSpeakerCount := showNextSpeakers
+
+		if len(speakersWaiting) < showNextSpeakerCount {
+			showNextSpeakerCount = len(speakersWaiting)
+		}
+
+		speakersWaiting = speakersWaiting[0:showNextSpeakerCount]
 	}
 
 	if speakersFinished == nil {


### PR DESCRIPTION
This PR prevents a panic when `agenda_show_next_speakers` is configured greater than available `speakersWaiting`. In case that  less `speakersWaiting` are available than configured, now all available speakers are used.

> github.com/OpenSlides/openslides3-autoupdate-service/internal/apps/agenda.listOfSpeakerSlideData(0xa0bda0, 0xc0002bc000, 0xc0002d9320, 0x1, 0xc0002dac50, 0xe, 0xd13138, 0x0, 0x0, 0xc0002dac40, ...)
> panic: runtime error: slice bounds out of range [:1] with capacity 0