### PR TITLE
Remove non-error log messages

### DIFF
--- a/internal/datastore/datastore.go
+++ b/internal/datastore/datastore.go
@@ -221,8 +221,6 @@ func (d *Datastore) update(data map[string]json.RawMessage, changeID int) (err e
 	d.maxChangeID = changeID
 	d.mu.Unlock()
 
-	log.Println("Recieve data update to changeID: ", changeID)
-
 	defer func() {
 		var cErr conditionError
 		if !errors.As(err, &cErr) {

--- a/internal/datastore/projector.go
+++ b/internal/datastore/projector.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"log"
 	"strconv"
 	"strings"
 	"sync"
@@ -151,7 +150,6 @@ func (p *Projectors) Update(data map[string]json.RawMessage) error {
 		return nil
 	}
 
-	log.Println("Projector-Data changed: ", changed)
 	p.topic.Publish(changed...)
 	return nil
 }

--- a/internal/http/interface.go
+++ b/internal/http/interface.go
@@ -9,3 +9,8 @@ import (
 type Auther interface {
 	Authenticate(r *http.Request) (context.Context, error)
 }
+
+// flusher is the same as http.Flusher
+type flusher interface {
+	Flush()
+}


### PR DESCRIPTION
This removes all log messages, that are no error messages.

After this commit, all of stdout is an error log that should be send to me for debugging.

If you need development output for debugging, use the /metrics url.