### PR TITLE
Remove speaker note for unauthorized users

### DIFF
--- a/cmd/autoupdate/main.go
+++ b/cmd/autoupdate/main.go
@@ -226,8 +226,8 @@ func openslidesRequiredUsers() map[string]func(json.RawMessage) (map[int]bool, s
 func openslidesRestricters(ds restricter.HasPermer) map[string]restricter.Element {
 	basePerm := restricter.BasePermission(ds)
 	return map[string]restricter.Element{
-		"agenda/item":             agenda.Restrict(ds),
-		"agenda/list-of-speakers": basePerm(agenda.CanSeeListOfSpeakers),
+		"agenda/item":             agenda.RestrictItem(ds),
+		"agenda/list-of-speakers": agenda.RestrictListOfSpeakers(ds),
 
 		"assignments/assignment":        basePerm(assignment.CanSee),
 		"assignments/assignment-poll":   poll.RestrictPoll(ds, assignment.CanSee, assignment.CanManage, []string{"amount_global_yes", "amount_global_no", "amount_global_abstain"}),

--- a/internal/apps/agenda/models.go
+++ b/internal/apps/agenda/models.go
@@ -26,12 +26,13 @@ type listOfSpeakers struct {
 		Collection string `json:"collection"`
 	} `json:"content_object"`
 	Speakers []struct {
-		UserID       int                    `json:"user_id"`
-		Marked       json.RawMessage        `json:"marked"`
-		PointOfOrder bool                   `json:"point_of_order"`
-		Weight       *projector.OptionalInt `json:"weight"`
-		BeginTime    json.RawMessage        `json:"begin_time"`
-		EndTime      json.RawMessage        `json:"end_time"`
+		UserID       int                     `json:"user_id"`
+		Marked       json.RawMessage         `json:"marked"`
+		PointOfOrder bool                    `json:"point_of_order"`
+		ProSpeech    *projector.OptionalBool `json:"pro_speech"`
+		Weight       *projector.OptionalInt  `json:"weight"`
+		BeginTime    json.RawMessage         `json:"begin_time"`
+		EndTime      json.RawMessage         `json:"end_time"`
 	} `json:"speakers"`
 	Closed json.RawMessage `json:"closed"`
 }

--- a/internal/apps/agenda/projector.go
+++ b/internal/apps/agenda/projector.go
@@ -159,11 +159,12 @@ func ListOfSpeakersSlide() projector.CallableFunc {
 }
 
 type formattedSpeaker struct {
-	User         string                 `json:"user"`
-	Marked       json.RawMessage        `json:"marked"`
-	PointOfOrder bool                   `json:"point_of_order"`
-	Weight       *projector.OptionalInt `json:"weight"`
-	EndTime      json.RawMessage        `json:"end_time"`
+	User         string                  `json:"user"`
+	Marked       json.RawMessage         `json:"marked"`
+	PointOfOrder bool                    `json:"point_of_order"`
+	ProSpeech    *projector.OptionalBool `json:"pro_speech"`
+	Weight       *projector.OptionalInt  `json:"weight"`
+	EndTime      json.RawMessage         `json:"end_time"`
 }
 
 func titleInformation(ds projector.Datastore, los listOfSpeakers) (map[string]*projector.OptionalStr, error) {
@@ -218,6 +219,7 @@ func listOfSpeakerSlideData(ds projector.Datastore, los listOfSpeakers) (json.Ra
 			User:         username,
 			Marked:       speaker.Marked,
 			PointOfOrder: speaker.PointOfOrder,
+			ProSpeech:    speaker.ProSpeech,
 			Weight:       speaker.Weight,
 			EndTime:      speaker.EndTime,
 		}

--- a/internal/apps/agenda/restrict.go
+++ b/internal/apps/agenda/restrict.go
@@ -14,11 +14,12 @@ const (
 
 	// CanSeeListOfSpeakers is the permission string if a user can see the list
 	// of speakers.
-	CanSeeListOfSpeakers = "agenda.can_see_list_of_speakers"
+	CanSeeListOfSpeakers     = "agenda.can_see_list_of_speakers"
+	pCanManageListOfSpeakers = "agenda.can_manage_list_of_speakers"
 )
 
-// Restrict handels restrictions of agenda/item elements.
-func Restrict(r restricter.HasPermer) restricter.ElementFunc {
+// RestrictItem handels restrictions of agenda/item elements.
+func RestrictItem(r restricter.HasPermer) restricter.ElementFunc {
 	return func(uid int, element json.RawMessage) (json.RawMessage, error) {
 		if !r.HasPerm(uid, pCanSee) {
 			return nil, nil
@@ -63,6 +64,59 @@ func Restrict(r restricter.HasPermer) restricter.ElementFunc {
 		element, err := json.Marshal(agendaData)
 		if err != nil {
 			return nil, fmt.Errorf("encoding itemdata: %w", err)
+		}
+		return element, nil
+	}
+}
+
+// RestrictListOfSpeakers restricts the list of speakers: The field "note" is
+// removed for every speaker, if the user is not a manager, the speaker user or
+// the config agenda_list_of_speakers_speaker_note_for_everyone is set.
+func RestrictListOfSpeakers(r restricter.HasPermer) restricter.ElementFunc {
+	return func(uid int, element json.RawMessage) (json.RawMessage, error) {
+		if !r.HasPerm(uid, CanSeeListOfSpeakers) {
+			return nil, nil
+		}
+
+		var notesForEveryone bool
+		if err := r.ConfigValue("agenda_list_of_speakers_speaker_note_for_everyone", &notesForEveryone); err != nil {
+			return nil, fmt.Errorf("getting agenda_list_of_speakers_speaker_note_for_everyone: %w", err)
+		}
+
+		if notesForEveryone || r.HasPerm(uid, pCanManageListOfSpeakers) {
+			return element, nil
+		}
+
+		// Delete each speaker's note for speakers which user is not the one to restrict for.
+		var los map[string]json.RawMessage
+		if err := json.Unmarshal(element, &los); err != nil {
+			return nil, fmt.Errorf("decoding list of speakers: %w", err)
+		}
+		var speakers []map[string]json.RawMessage
+		if err := json.Unmarshal(los["speakers"], &speakers); err != nil {
+			return nil, fmt.Errorf("decoding speakers: %w", err)
+		}
+
+		for _, speaker := range speakers {
+			var userId int
+			if err := json.Unmarshal(speaker["user_id"], &userId); err != nil {
+				return nil, fmt.Errorf("decoding speaker: %w", err)
+			}
+			if uid == userId {
+				continue
+			}
+			delete(speaker, "note")
+		}
+
+		speakersEncoded, err := json.Marshal(speakers)
+		if err != nil {
+			return nil, fmt.Errorf("encoding speakers: %w", err)
+		}
+
+		los["speakers"] = speakersEncoded
+		element, err = json.Marshal(los)
+		if err != nil {
+			return nil, fmt.Errorf("encoding list of speakers: %w", err)
 		}
 		return element, nil
 	}

--- a/internal/apps/agenda/restrict_test.go
+++ b/internal/apps/agenda/restrict_test.go
@@ -51,7 +51,7 @@ const (
 
 func TestRestrict(t *testing.T) {
 	permer := new(test.HasPermMock)
-	r := agenda.Restrict(permer)
+	r := agenda.RestrictItem(permer)
 
 	for _, tt := range []struct {
 		name     string

--- a/internal/projector/helpers.go
+++ b/internal/projector/helpers.go
@@ -119,3 +119,44 @@ func (o *OptionalStr) MarshalJSON() ([]byte, error) {
 	}
 	return json.Marshal(o.value)
 }
+
+// OptionalBool is a type that can be null or an bool.
+type OptionalBool struct {
+	value bool
+	exist bool
+}
+
+// Value returns the value of the type. Returns false if it does not exist.
+func (o *OptionalBool) Value() bool {
+	if o == nil {
+		return false
+	}
+	return o.value
+}
+
+// Null returns true, if, the value does not exist.
+func (o *OptionalBool) Null() bool {
+	if o == nil {
+		return true
+	}
+	return !o.exist
+}
+
+// UnmarshalJSON builds this type from json.
+func (o *OptionalBool) UnmarshalJSON(b []byte) error {
+	if bytes.Equal(b, []byte(`null`)) {
+		o.exist = false
+		return nil
+	}
+
+	o.exist = true
+	return json.Unmarshal(b, &o.value)
+}
+
+// MarshalJSON decodes the type to json.
+func (o *OptionalBool) MarshalJSON() ([]byte, error) {
+	if o.Null() {
+		return []byte(`null`), nil
+	}
+	return json.Marshal(o.value)
+}

--- a/internal/restricter/interface.go
+++ b/internal/restricter/interface.go
@@ -14,11 +14,12 @@ type Element interface {
 	Restrict(int, json.RawMessage) (json.RawMessage, error)
 }
 
-// HasPermer tells if a user has a specivic perm.
+// HasPermer tells if a user has a specific perm.
 type HasPermer interface {
 	HasPerm(uid int, perm string) bool
 	IsSuperadmin(uid int) bool
 	InGroups(uid int, groups []int) bool
 	UserRequired(uid int) []string
 	Get(collection string, id int, v interface{}) error
+	ConfigValue(key string, v interface{}) error
 }

--- a/internal/test/export.json
+++ b/internal/test/export.json
@@ -62909,6 +62909,7 @@
               "user": "speaker2",
               "marked": false,
               "point_of_order": false,
+              "pro_speech": null,
               "weight": 2,
               "end_time": null
             }
@@ -62917,6 +62918,7 @@
             "user": "title speaker1 the last name (layer X)",
             "marked": false,
             "point_of_order": false,
+            "pro_speech": null,
             "weight": null,
             "end_time": null
           },
@@ -63103,6 +63105,7 @@
               "user": "speaker2",
               "marked": false,
               "point_of_order": false,
+              "pro_speech": null,
               "weight": 2,
               "end_time": null
             }
@@ -63111,6 +63114,7 @@
             "user": "title speaker1 the last name (layer X)",
             "marked": false,
             "point_of_order": false,
+            "pro_speech": null,
             "weight": null,
             "end_time": null
           },
@@ -63419,6 +63423,7 @@
               "user": "candidate1",
               "marked": false,
               "point_of_order": false,
+              "pro_speech": null,
               "weight": 1,
               "end_time": null
             },
@@ -63426,6 +63431,7 @@
               "user": "candidate2",
               "marked": false,
               "point_of_order": false,
+              "pro_speech": null,
               "weight": 2,
               "end_time": null
             },
@@ -63433,6 +63439,7 @@
               "user": "all perms",
               "marked": false,
               "point_of_order": false,
+              "pro_speech": null,
               "weight": 3,
               "end_time": null
             }
@@ -63620,6 +63627,7 @@
               "user": "candidate1",
               "marked": false,
               "point_of_order": false,
+              "pro_speech": null,
               "weight": 1,
               "end_time": null
             },
@@ -63627,6 +63635,7 @@
               "user": "candidate2",
               "marked": false,
               "point_of_order": false,
+              "pro_speech": null,
               "weight": 2,
               "end_time": null
             },
@@ -63634,6 +63643,7 @@
               "user": "all perms",
               "marked": false,
               "point_of_order": false,
+              "pro_speech": null,
               "weight": 3,
               "end_time": null
             }
@@ -63938,6 +63948,7 @@
               "user": "candidate1",
               "marked": false,
               "point_of_order": false,
+              "pro_speech": null,
               "weight": 1,
               "end_time": null
             }
@@ -64125,6 +64136,7 @@
               "user": "candidate1",
               "marked": false,
               "point_of_order": false,
+              "pro_speech": null,
               "weight": 1,
               "end_time": null
             }
@@ -71521,6 +71533,7 @@
               "user": "Administrator",
               "marked": false,
               "point_of_order": true,
+              "pro_speech": null,
               "weight": 1,
               "end_time": null
             },
@@ -71528,6 +71541,7 @@
               "user": "Administrator",
               "marked": false,
               "point_of_order": false,
+              "pro_speech": null,
               "weight": 2,
               "end_time": null
             }
@@ -71536,6 +71550,7 @@
             "user": "title speaker1 the last name (layer X)",
             "marked": false,
             "point_of_order": false,
+            "pro_speech": null,
             "weight": null,
             "end_time": null
           },
@@ -71722,6 +71737,7 @@
               "user": "Administrator",
               "marked": false,
               "point_of_order": true,
+              "pro_speech": null,
               "weight": 1,
               "end_time": null
             },
@@ -71729,6 +71745,7 @@
               "user": "Administrator",
               "marked": false,
               "point_of_order": false,
+              "pro_speech": null,
               "weight": 2,
               "end_time": null
             }
@@ -71737,6 +71754,7 @@
             "user": "title speaker1 the last name (layer X)",
             "marked": false,
             "point_of_order": false,
+            "pro_speech": null,
             "weight": null,
             "end_time": null
           },
@@ -73204,6 +73222,7 @@
               "user": "Administrator",
               "marked": false,
               "point_of_order": true,
+              "pro_speech": null,
               "weight": 1,
               "end_time": null
             },
@@ -73211,6 +73230,7 @@
               "user": "Administrator",
               "marked": false,
               "point_of_order": false,
+              "pro_speech": null,
               "weight": 2,
               "end_time": null
             }
@@ -73219,6 +73239,7 @@
             "user": "title speaker1 the last name (layer X)",
             "marked": false,
             "point_of_order": false,
+            "pro_speech": null,
             "weight": null,
             "end_time": null
           },
@@ -75946,6 +75967,7 @@
               "user": "speaker2",
               "marked": false,
               "point_of_order": false,
+              "pro_speech": null,
               "weight": 2,
               "end_time": null
             }
@@ -75954,6 +75976,7 @@
             "user": "title speaker1 the last name (layer X)",
             "marked": false,
             "point_of_order": false,
+            "pro_speech": null,
             "weight": null,
             "end_time": null
           },
@@ -79593,6 +79616,7 @@
               "user": "candidate1",
               "marked": false,
               "point_of_order": false,
+              "pro_speech": null,
               "weight": 1,
               "end_time": null
             }
@@ -80055,6 +80079,7 @@
               "user": "candidate1",
               "marked": false,
               "point_of_order": false,
+              "pro_speech": null,
               "weight": 1,
               "end_time": null
             },
@@ -80062,6 +80087,7 @@
               "user": "candidate2",
               "marked": false,
               "point_of_order": false,
+              "pro_speech": null,
               "weight": 2,
               "end_time": null
             },
@@ -80069,6 +80095,7 @@
               "user": "all perms",
               "marked": false,
               "point_of_order": false,
+              "pro_speech": null,
               "weight": 3,
               "end_time": null
             }

--- a/internal/test/export.json.go
+++ b/internal/test/export.json.go
@@ -62157,6 +62157,7 @@ var exampleProjector = []projectorData{
               "user": "speaker2",
               "marked": false,
               "point_of_order": false,
+              "pro_speech": null,
               "weight": 2,
               "end_time": null
             }
@@ -62165,6 +62166,7 @@ var exampleProjector = []projectorData{
             "user": "title speaker1 the last name (layer X)",
             "marked": false,
             "point_of_order": false,
+            "pro_speech": null,
             "weight": null,
             "end_time": null
           },
@@ -62351,6 +62353,7 @@ var exampleProjector = []projectorData{
               "user": "speaker2",
               "marked": false,
               "point_of_order": false,
+              "pro_speech": null,
               "weight": 2,
               "end_time": null
             }
@@ -62359,6 +62362,7 @@ var exampleProjector = []projectorData{
             "user": "title speaker1 the last name (layer X)",
             "marked": false,
             "point_of_order": false,
+            "pro_speech": null,
             "weight": null,
             "end_time": null
           },
@@ -62667,6 +62671,7 @@ var exampleProjector = []projectorData{
               "user": "candidate1",
               "marked": false,
               "point_of_order": false,
+              "pro_speech": null,
               "weight": 1,
               "end_time": null
             },
@@ -62674,6 +62679,7 @@ var exampleProjector = []projectorData{
               "user": "candidate2",
               "marked": false,
               "point_of_order": false,
+              "pro_speech": null,
               "weight": 2,
               "end_time": null
             },
@@ -62681,6 +62687,7 @@ var exampleProjector = []projectorData{
               "user": "all perms",
               "marked": false,
               "point_of_order": false,
+              "pro_speech": null,
               "weight": 3,
               "end_time": null
             }
@@ -62868,6 +62875,7 @@ var exampleProjector = []projectorData{
               "user": "candidate1",
               "marked": false,
               "point_of_order": false,
+              "pro_speech": null,
               "weight": 1,
               "end_time": null
             },
@@ -62875,6 +62883,7 @@ var exampleProjector = []projectorData{
               "user": "candidate2",
               "marked": false,
               "point_of_order": false,
+              "pro_speech": null,
               "weight": 2,
               "end_time": null
             },
@@ -62882,6 +62891,7 @@ var exampleProjector = []projectorData{
               "user": "all perms",
               "marked": false,
               "point_of_order": false,
+              "pro_speech": null,
               "weight": 3,
               "end_time": null
             }
@@ -63186,6 +63196,7 @@ var exampleProjector = []projectorData{
               "user": "candidate1",
               "marked": false,
               "point_of_order": false,
+              "pro_speech": null,
               "weight": 1,
               "end_time": null
             }
@@ -63373,6 +63384,7 @@ var exampleProjector = []projectorData{
               "user": "candidate1",
               "marked": false,
               "point_of_order": false,
+              "pro_speech": null,
               "weight": 1,
               "end_time": null
             }
@@ -70769,6 +70781,7 @@ var exampleProjector = []projectorData{
               "user": "Administrator",
               "marked": false,
               "point_of_order": true,
+              "pro_speech": null,
               "weight": 1,
               "end_time": null
             },
@@ -70776,6 +70789,7 @@ var exampleProjector = []projectorData{
               "user": "Administrator",
               "marked": false,
               "point_of_order": false,
+              "pro_speech": null,
               "weight": 2,
               "end_time": null
             }
@@ -70784,6 +70798,7 @@ var exampleProjector = []projectorData{
             "user": "title speaker1 the last name (layer X)",
             "marked": false,
             "point_of_order": false,
+            "pro_speech": null,
             "weight": null,
             "end_time": null
           },
@@ -70970,6 +70985,7 @@ var exampleProjector = []projectorData{
               "user": "Administrator",
               "marked": false,
               "point_of_order": true,
+              "pro_speech": null,
               "weight": 1,
               "end_time": null
             },
@@ -70977,6 +70993,7 @@ var exampleProjector = []projectorData{
               "user": "Administrator",
               "marked": false,
               "point_of_order": false,
+              "pro_speech": null,
               "weight": 2,
               "end_time": null
             }
@@ -70985,6 +71002,7 @@ var exampleProjector = []projectorData{
             "user": "title speaker1 the last name (layer X)",
             "marked": false,
             "point_of_order": false,
+            "pro_speech": null,
             "weight": null,
             "end_time": null
           },
@@ -72452,6 +72470,7 @@ var exampleProjector = []projectorData{
               "user": "Administrator",
               "marked": false,
               "point_of_order": true,
+              "pro_speech": null,
               "weight": 1,
               "end_time": null
             },
@@ -72459,6 +72478,7 @@ var exampleProjector = []projectorData{
               "user": "Administrator",
               "marked": false,
               "point_of_order": false,
+              "pro_speech": null,
               "weight": 2,
               "end_time": null
             }
@@ -72467,6 +72487,7 @@ var exampleProjector = []projectorData{
             "user": "title speaker1 the last name (layer X)",
             "marked": false,
             "point_of_order": false,
+            "pro_speech": null,
             "weight": null,
             "end_time": null
           },
@@ -75194,6 +75215,7 @@ var exampleProjector = []projectorData{
               "user": "speaker2",
               "marked": false,
               "point_of_order": false,
+              "pro_speech": null,
               "weight": 2,
               "end_time": null
             }
@@ -75202,6 +75224,7 @@ var exampleProjector = []projectorData{
             "user": "title speaker1 the last name (layer X)",
             "marked": false,
             "point_of_order": false,
+            "pro_speech": null,
             "weight": null,
             "end_time": null
           },
@@ -78841,6 +78864,7 @@ var exampleProjector = []projectorData{
               "user": "candidate1",
               "marked": false,
               "point_of_order": false,
+              "pro_speech": null,
               "weight": 1,
               "end_time": null
             }
@@ -79303,6 +79327,7 @@ var exampleProjector = []projectorData{
               "user": "candidate1",
               "marked": false,
               "point_of_order": false,
+              "pro_speech": null,
               "weight": 1,
               "end_time": null
             },
@@ -79310,6 +79335,7 @@ var exampleProjector = []projectorData{
               "user": "candidate2",
               "marked": false,
               "point_of_order": false,
+              "pro_speech": null,
               "weight": 2,
               "end_time": null
             },
@@ -79317,6 +79343,7 @@ var exampleProjector = []projectorData{
               "user": "all perms",
               "marked": false,
               "point_of_order": false,
+              "pro_speech": null,
               "weight": 3,
               "end_time": null
             }

--- a/internal/test/has_perm_mock.go
+++ b/internal/test/has_perm_mock.go
@@ -74,7 +74,7 @@ func (h *HasPermMock) Get(collection string, id int, v interface{}) error {
 	return json.Unmarshal(e, v)
 }
 
-// ConfigValue is currently a stub until it is actually needed by the tests 
+// ConfigValue is currently a stub until it is actually needed by the tests
 func (h *HasPermMock) ConfigValue(key string, v interface{}) error {
 	return nil
 }

--- a/internal/test/has_perm_mock.go
+++ b/internal/test/has_perm_mock.go
@@ -73,3 +73,8 @@ func (h *HasPermMock) Get(collection string, id int, v interface{}) error {
 	}
 	return json.Unmarshal(e, v)
 }
+
+// ConfigValue is currently a stub until it is actually needed by the tests 
+func (h *HasPermMock) ConfigValue(key string, v interface{}) error {
+	return nil
+}


### PR DESCRIPTION
@ostcar The input has the following form:
```
{
  "speakers": [
    {
      "note": "xyz",
      "other_fields": "other values",
    }
  ],
  "other fields": "other values",
}
```
And the field "note" should be removed, if `user_id!=uid`, so keeping the note just for oneself.

I tried using
```
var los struct {
  Speakers map[string]json.RawMessage `json:"speakers"`
}
```
for en-/decoding the json and more elegant code. But this removes all extra keys in the json, so now always use `map[string]json.RawMessage`. Is there a more elegant way of doing this?