### PR TITLE
Separate speaker in name and level for chyron

### DIFF
--- a/internal/apps/agenda/projector.go
+++ b/internal/apps/agenda/projector.go
@@ -424,10 +424,12 @@ func CurrentSpeakerChyronSlide() projector.CallableFunc {
 			return nil, fmt.Errorf("getting current list of speakers: %w", err)
 		}
 
-		var current string
+		var userName string
+		var userLevel string
 		for _, speaker := range los.Speakers {
 			if !bytes.Equal(speaker.BeginTime, []byte("null")) && bytes.Equal(speaker.EndTime, []byte("null")) {
-				current, err = user.GetUserName(ds, speaker.UserID)
+				userName, err = user.GetUserShortName(ds, speaker.UserID)
+				userLevel, err = user.GetUserLevel(ds, speaker.UserID)
 				if err != nil {
 					return nil, fmt.Errorf("getting username: %w", err)
 				}
@@ -435,8 +437,12 @@ func CurrentSpeakerChyronSlide() projector.CallableFunc {
 			}
 		}
 
-		if current != "" {
-			currentSpeaker["current_speaker"] = []byte(`"` + current + `"`)
+		if userName != "" {
+			currentSpeaker["current_speaker_name"] = []byte(`"` + userName + `"`)
+		}
+
+		if userLevel != "" {
+			currentSpeaker["current_speaker_level"] = []byte(`"` + userLevel + `"`)
 		}
 
 		b, err := json.Marshal(currentSpeaker)

--- a/internal/apps/user/projector.go
+++ b/internal/apps/user/projector.go
@@ -39,14 +39,13 @@ func Slide() projector.CallableFunc {
 	}
 }
 
-// GetUserName returns the display name for an user id.
-func GetUserName(ds projector.Datastore, uid int) (string, error) {
+// GetUserShortName returns the short display name for an user id (name without structure_level)
+func GetUserShortName(ds projector.Datastore, uid int) (string, error) {
 	var user struct {
 		Username  string `json:"username"`
 		Title     string `json:"title"`
 		FirstName string `json:"first_name"`
 		LastName  string `json:"last_name"`
-		Level     string `json:"structure_level"`
 	}
 
 	if err := ds.Get("users/user", uid, &user); err != nil {
@@ -68,9 +67,34 @@ func GetUserName(ds projector.Datastore, uid int) (string, error) {
 		return user.Username, nil
 	}
 
-	if user.Level != "" {
-		parts = append(parts, fmt.Sprintf("(%s)", user.Level))
+	return strings.Join(parts, " "), nil
+}
+
+// GetUserLevel returns the structre level for user id.
+func GetUserLevel(ds projector.Datastore, uid int) (string, error) {
+	var user struct {
+		Level string `json:"structure_level"`
 	}
 
-	return strings.Join(parts, " "), nil
+	if err := ds.Get("users/user", uid, &user); err != nil {
+		return "", projector.NewClientError("users/user with id %d does not exist", uid)
+	}
+
+	return user.Level, nil
+}
+
+// GetUserName returns the display name for an user id.
+func GetUserName(ds projector.Datastore, uid int) (string, error) {
+	shotName, err := GetUserShortName(ds, uid)
+	if err != nil {
+		return "", fmt.Errorf("getting short name: %w", err)
+	}
+
+	structureLevel, _ := GetUserLevel(ds, uid)
+
+	if structureLevel != "" {
+		return fmt.Sprintf("%s (%s)", shotName, structureLevel), nil
+	}
+
+	return shotName, nil
 }

--- a/internal/test/export.json
+++ b/internal/test/export.json
@@ -63015,7 +63015,8 @@
         "data": {
           "background_color": "#317796",
           "font_color": "#ffffff",
-          "current_speaker": "title speaker1 the last name (layer X)"
+          "current_speaker_level": "layer X",
+          "current_speaker_name": "title speaker1 the last name"
         },
         "element": {
           "name": "agenda/current-speaker-chyron",
@@ -71647,7 +71648,8 @@
         "data": {
           "background_color": "#317796",
           "font_color": "#ffffff",
-          "current_speaker": "title speaker1 the last name (layer X)"
+          "current_speaker_level": "layer X",
+          "current_speaker_name": "title speaker1 the last name"
         },
         "element": {
           "name": "agenda/current-speaker-chyron",

--- a/internal/test/export.json.go
+++ b/internal/test/export.json.go
@@ -62263,7 +62263,8 @@ var exampleProjector = []projectorData{
         "data": {
           "background_color": "#317796",
           "font_color": "#ffffff",
-          "current_speaker": "title speaker1 the last name (layer X)"
+          "current_speaker_level": "layer X",
+          "current_speaker_name": "title speaker1 the last name"
         },
         "element": {
           "name": "agenda/current-speaker-chyron",
@@ -70895,7 +70896,8 @@ var exampleProjector = []projectorData{
         "data": {
           "background_color": "#317796",
           "font_color": "#ffffff",
-          "current_speaker": "title speaker1 the last name (layer X)"
+          "current_speaker_level": "layer X",
+          "current_speaker_name": "title speaker1 the last name"
         },
         "element": {
           "name": "agenda/current-speaker-chyron",


### PR DESCRIPTION
Alters CurrentSpeakerChyronSlide so speaker name and speaker structure
level were send seperately. This was required since both fields need to
be displayed in separate ways.

Also alters GetUserName to support short names, structure level and full names