### PR TITLE
fix build after go version bump

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN apk --no-cache add git
 COPY go.mod go.sum ./
 RUN go mod download
 COPY . .
-RUN CGO_ENABLED=0 go build ./cmd/autoupdate
+RUN CGO_ENABLED=0 go build -buildvcs=false ./cmd/autoupdate
 
 # Development build.
 FROM builder as development


### PR DESCRIPTION
This is basically just following the error message adding the `-buildvcs=false` flag to `go build`

I read [this](https://github.com/golang/go/issues/49004) which seemed to imply the default for the `buildvcs` changed from go 1.17 to go 1.18.
As I'm also not sure what VCS (stamping) is, maybe you @ostcar can find a cleaner solution for this.

This is just a quick fix.
also @emanuelschuetze 